### PR TITLE
Add name to Slack message

### DIFF
--- a/lib/emojibot/bot.ex
+++ b/lib/emojibot/bot.ex
@@ -4,7 +4,7 @@ defmodule Emojibot.Bot do
 
   def handle_event(%{name: name, type: "emoji_changed", subtype: "add"}, slack, state) do
     emoji_channel = Application.get_env(:emojibot, :emoji_channel)
-    send_message(":#{name}:", emoji_channel, slack)
+    send_message(":#{name}: (name)", emoji_channel, slack)
 
     {:ok, state}
   end


### PR DESCRIPTION
To get a little bit more context on what represent the newly created emoji, I propose we display the name in the Slack message. On desktop you can hover and check the tooltip but on mobile there is no way to know the handle.

```
:slack: (slack)
```